### PR TITLE
transform Object.assign for IE11 Support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
     "presets": ["es2015", "react", "stage-1"],
     "plugins": [
         "transform-es3-member-expression-literals",
-        "transform-es3-property-literals"
+        "transform-es3-property-literals",
+        "transform-object-assign"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
     "babel-plugin-transform-es3-property-literals": "^6.5.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
Object.assign is not supported in IE11, so this component will not currently work on that browser
![ie11-object-assign](https://cloud.githubusercontent.com/assets/1483361/16419989/a3c14c52-3d1d-11e6-843e-5b8c36459347.PNG)
