### PR TITLE
[FIX] synchronous style properties assign

### DIFF
--- a/lib/easy-transition.js
+++ b/lib/easy-transition.js
@@ -113,7 +113,9 @@ var TransitionChild = function (_Component2) {
                 return window.getComputedStyle(_this3.page)[property];
             });
             this.page.style.transition = this.props.transition;
-            Object.assign(this.page.style, this.props.finalStyle);
+            setTimeout(function(){
+              Object.assign(this.page.style, this.props.finalStyle);
+            });
             var transitionsRemaining = this.props.transition.split(',').length;
             this.page.addEventListener("transitionend", function (event) {
                 transitionsRemaining--;

--- a/lib/easy-transition.js
+++ b/lib/easy-transition.js
@@ -114,7 +114,7 @@ var TransitionChild = function (_Component2) {
             });
             this.page.style.transition = this.props.transition;
             setTimeout(function(){
-              Object.assign(this.page.style, this.props.finalStyle);
+              Object.assign(_this3.page.style, _this3.props.finalStyle);
             });
             var transitionsRemaining = this.props.transition.split(',').length;
             this.page.addEventListener("transitionend", function (event) {

--- a/src/easy-transition.js
+++ b/src/easy-transition.js
@@ -46,7 +46,7 @@ class TransitionChild extends Component {
         Object.assign(this.page.style, this.props.initialStyle)
         Object.keys(this.props.initialStyle).forEach(property => window.getComputedStyle(this.page)[property])
         this.page.style.transition = this.props.transition
-        Object.assign(this.page.style, this.props.finalStyle)
+        setTimeout(() => Object.assign(this.page.style, this.props.finalStyle))
         let transitionsRemaining = this.props.transition.split(',').length
         this.page.addEventListener("transitionend", (event) => {
             transitionsRemaining--


### PR DESCRIPTION
``` javascript
    componentFadeIn(callback) {
        // this line
        Object.assign(this.page.style, this.props.initialStyle)
        Object.keys(this.props.initialStyle).forEach(property => window.getComputedStyle(this.page)[property])
        this.page.style.transition = this.props.transition
        // and this one will be executed at once, in some cases. 
        // this leads to the issue when 'transitionend' event will not triggered 
        // because element appears already with final styles.
        Object.assign(this.page.style, this.props.finalStyle)
        let transitionsRemaining = this.props.transition.split(',').length
        this.page.addEventListener("transitionend", (event) => {
            transitionsRemaining--
            if (transitionsRemaining) return
            callback()
        }, false)
    }
```

I am fixed that by wrapping finalStyles in setTimeout.
