### PR TITLE
Allow higher node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Easy transitions with React and React-router",
   "main": "./lib/ReactEasyTransition.js",
   "engines": {
-    "node": "7.2.1"
+    "node": ">=7.2.1"
   },
   "files": [
     "*.md",


### PR DESCRIPTION
The current engine for node config breaks Yarn installs since it only allows version 7.2.1 By allowing >=7.2.1 it works on both npm and yarn