### PR TITLE
Added a README note to warn when using "transition: all"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can set a custom component or classname if needed
 </EasyTransition>
 ```
 
-NOTE: If your "<Link>" component (or any child of this) has any styling / classes that use "transition", make sure not to use "transition: all" as this will prevent react-easy-transition from fading out.
+**NOTE**: If your `<Link` component (or any child of this) has any styling / classes that use `transition`, make sure not to use `transition: all` as this will prevent react-easy-transition from fading out.
 
 ## Live Demo
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can set a custom component or classname if needed
 </EasyTransition>
 ```
 
+NOTE: If your <Link> component (or any child of this) has any styling / classes that use "transition", make sure not to use "transition: all" as this will prevent react-easy-transition from fading out.
+
 ## Live Demo
 
 [Live Demo here](https://react-easy-transition.herokuapp.com/)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can set a custom component or classname if needed
 </EasyTransition>
 ```
 
-NOTE: If your <Link> component (or any child of this) has any styling / classes that use "transition", make sure not to use "transition: all" as this will prevent react-easy-transition from fading out.
+NOTE: If your "<Link>" component (or any child of this) has any styling / classes that use "transition", make sure not to use "transition: all" as this will prevent react-easy-transition from fading out.
 
 ## Live Demo
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can set a custom component or classname if needed
 </EasyTransition>
 ```
 
-**NOTE**: If your `<Link` component (or any child of this) has any styling / classes that use `transition`, make sure not to use `transition: all` as this will prevent react-easy-transition from fading out.
+**NOTE**: If your `<Link>` component (or any child of this) has any styling / classes that use `transition`, make sure not to use `transition: all` as this will prevent react-easy-transition from fading out.
 
 ## Live Demo
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can set a custom component or classname if needed
 </EasyTransition>
 ```
 
-**NOTE**: If your `<Link>` component (or any child of this) has any styling / classes that use `transition`, make sure not to use `transition: all` as this will prevent react-easy-transition from fading out.
+**NOTE**: If your `<Link>` component (or any children of this) contains styling/classes that use `transition`, make sure **not** to use `transition: all` as this will prevent react-easy-transition from fading out.
 
 ## Live Demo
 


### PR DESCRIPTION
Using "transition: all" stops react-easy-transition from behaving correctly, as it shares the transition  property.